### PR TITLE
feat: Create Chrome extension for Google Drive vocabulary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release Chrome Extension
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Package extension
+        run: |
+          cd chrome
+          zip -r ../extension.zip .
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./extension.zip
+          asset_name: extension.zip
+          asset_content_type: application/zip

--- a/README.md
+++ b/README.md
@@ -1,0 +1,74 @@
+# Google Drive Vocabulary Chrome Extension
+
+This Chrome extension helps you build your vocabulary by translating English words to Korean and saving them to a Google Doc in your Google Drive.
+
+## Features
+
+- **Translate English to Korean:** Utilizes Google's translation capabilities to provide accurate translations.
+- **Save to Google Drive:** Automatically saves translated words, their phonetic transcription, and meanings to a Google Doc.
+- **Daily Vocabulary Lists:** Organizes your vocabulary by date, creating a new Google Doc for each day.
+- **Append to Daily List:** Adds new words to the existing document for the day, creating a running list.
+
+## How to Install
+
+1.  **Download the Extension:** Download the latest release from the [GitHub Releases](https://github.com/your-username/your-repo/releases) page.
+2.  **Unzip the File:** Unzip the downloaded file to a location of your choice.
+3.  **Configure the Client ID:** Before loading the extension, you must configure your own Google OAuth 2.0 Client ID. Follow the steps in the **Configuration** section below.
+4.  **Enable Developer Mode in Chrome:** Open Chrome and navigate to `chrome://extensions`.
+5.  **Load the Extension:** Click on "Load unpacked" and select the unzipped directory.
+6.  **Authenticate with Google:** The first time you use the extension, you will be prompted to authenticate with your Google account to grant access to Google Drive.
+
+## Configuration: Setting up Google OAuth 2.0
+
+To use the Google Drive integration, you need to create your own OAuth 2.0 Client ID.
+
+1.  **Go to the Google Cloud Console:** Navigate to the [Google Cloud Console](https://console.cloud.google.com/).
+2.  **Create a New Project:** If you don't have one already, create a new project.
+3.  **Enable APIs:**
+    *   Go to "APIs & Services" > "Library".
+    *   Search for and enable the **Google Drive API**.
+    *   Search for and enable the **Google Docs API**.
+4.  **Configure OAuth Consent Screen:**
+    *   Go to "APIs & Services" > "OAuth consent screen".
+    *   Choose **External** and click "Create".
+    *   Fill in the required fields (App name, User support email, Developer contact information).
+    *   On the "Scopes" page, you don't need to add any scopes.
+    *   On the "Test users" page, add the Google account(s) you will use to test the extension.
+5.  **Create Credentials:**
+    *   Go to "APIs & Services" > "Credentials".
+    *   Click "Create Credentials" and select **OAuth client ID**.
+    *   For "Application type", select **Chrome app**.
+    *   Enter a name for your client ID.
+    *   For **Application ID**, you first need to load the extension in Chrome to get its ID:
+        *   Follow steps 4 and 5 in the "How to Install" section.
+        *   Once the extension is loaded, you will see its ID on the extension card in `chrome://extensions`. Copy this ID.
+    *   Paste the copied Application ID into the "Application ID" field in the Google Cloud Console and click "Create".
+6.  **Update the Manifest File:**
+    *   You will now see your Client ID. Copy it.
+    *   Open the `chrome/manifest.json` file in this project.
+    *   Replace `"YOUR_CLIENT_ID.apps.googleusercontent.com"` with the Client ID you just copied.
+    *   Save the file.
+7.  **Reload the Extension:** Go back to `chrome://extensions` and click the reload button on the extension card.
+
+## How to Use
+
+1.  **Translate a Word:** Highlight an English word on any webpage.
+2.  **Right-click and Translate:** Right-click on the highlighted word and select "Translate and Save to Google Drive" from the context menu.
+3.  **View Your Vocabulary List:** The translated word will be automatically added to a Google Doc in your Google Drive, named with the current date (e.g., "Vocabulary - YYYY-MM-DD").
+
+## Development Plan
+
+This project will be developed in the following phases:
+
+1.  **Core Extension Setup:** Create the basic structure of the Chrome extension, including the `manifest.json`, background scripts, and content scripts.
+2.  **Google Drive Integration:** Implement OAuth 2.0 to authenticate with the Google Drive API and add functionality to create and manage Google Docs.
+3.  **Translation Functionality:** Integrate a translation service to translate English words to Korean.
+4.  **CI/CD with GitHub Actions:** Set up a GitHub Actions workflow to automate the build and release process.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a pull request or open an issue.
+
+## License
+
+This project is licensed under the terms of the MIT license.

--- a/chrome/background.js
+++ b/chrome/background.js
@@ -1,0 +1,176 @@
+// background.js
+
+// When the extension is installed, create a context menu item.
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({
+    id: "translateAndSave",
+    title: "Translate and Save to Google Drive",
+    contexts: ["selection"]
+  });
+});
+
+// When the context menu item is clicked, this event listener will be triggered.
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+  if (info.menuItemId === "translateAndSave") {
+    const selectedText = info.selectionText;
+
+    // 1. Get word data (phonetics, definition, etc.)
+    getWordData(selectedText, (wordData) => {
+      if (!wordData) {
+        console.error("Could not retrieve data for the word:", selectedText);
+        // Even if dictionary fails, try to translate
+        wordData = { word: selectedText, phonetic: "", definition: "" };
+      }
+
+      // 2. Translate the word to Korean
+      translateToKorean(selectedText, (translatedText) => {
+        if (!translatedText) {
+          console.error("Could not translate the word:", selectedText);
+          return; // Stop if translation fails
+        }
+
+        // 3. Authenticate with Google and save to Drive
+        chrome.identity.getAuthToken({ interactive: true }, (token) => {
+          if (chrome.runtime.lastError) {
+            console.error(chrome.runtime.lastError);
+            return;
+          }
+
+          getOrCreateFileId(token, (fileId) => {
+            const formattedText = `${wordData.word} ${wordData.phonetic || ''}\n- ${translatedText}\n- ${wordData.definition || ''}`;
+            appendToFile(token, fileId, formattedText);
+          });
+        });
+      });
+    });
+  }
+});
+
+/**
+ * Translates text from English to Korean using the MyMemory API.
+ * @param {string} text - The text to translate.
+ * @param {function} callback - The callback function to execute with the translated text.
+ */
+function translateToKorean(text, callback) {
+  const url = `https://api.mymemory.translated.net/get?q=${encodeURIComponent(text)}&langpair=en|ko`;
+  fetch(url)
+    .then(response => response.json())
+    .then(data => {
+      if (data && data.responseData && data.responseData.translatedText) {
+        callback(data.responseData.translatedText);
+      } else {
+        callback(null);
+      }
+    })
+    .catch(error => {
+      console.error("Error during translation:", error);
+      callback(null);
+    });
+}
+
+
+/**
+ * Fetches word data from the dictionaryapi.dev API.
+ * @param {string} word - The word to look up.
+ * @param {function} callback - The callback function to execute with the word data.
+ */
+function getWordData(word, callback) {
+  fetch(`https://api.dictionaryapi.dev/api/v2/entries/en/${word}`)
+    .then(response => response.json())
+    .then(data => {
+      if (data && data.length > 0) {
+        const phonetic = data[0].phonetics.find(p => p.text)?.text || "";
+        const definition = data[0].meanings[0]?.definitions[0]?.definition || "";
+        callback({
+          word: data[0].word,
+          phonetic: phonetic,
+          definition: definition
+        });
+      } else {
+        callback(null);
+      }
+    })
+    .catch(error => {
+      console.error("Error fetching word data:", error);
+      callback(null);
+    });
+}
+
+
+/**
+ * Searches for the daily vocabulary file. If it doesn't exist, it creates one.
+ * @param {string} token - The OAuth 2.0 token.
+ * @param {function} callback - The callback function to execute with the file ID.
+ */
+function getOrCreateFileId(token, callback) {
+  const today = new Date().toISOString().slice(0, 10);
+  const fileName = `Vocabulary - ${today}`;
+  const query = `name='${fileName}' and mimeType='application/vnd.google-apps.document' and trashed=false`;
+
+  // Search for the file.
+  fetch(`https://www.googleapis.com/drive/v3/files?q=${encodeURIComponent(query)}`, {
+    headers: {
+      'Authorization': `Bearer ${token}`
+    }
+  })
+  .then(response => response.json())
+  .then(data => {
+    if (data.files.length > 0) {
+      // File exists, return the ID.
+      callback(data.files[0].id);
+    } else {
+      // File doesn't exist, create it.
+      const metadata = {
+        name: fileName,
+        mimeType: 'application/vnd.google-apps.document',
+        parents: ['root']
+      };
+      fetch('https://www.googleapis.com/drive/v3/files', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(metadata)
+      })
+      .then(response => response.json())
+      .then(file => {
+        callback(file.id);
+      });
+    }
+  });
+}
+
+/**
+ * Appends text to a Google Doc.
+ * @param {string} token - The OAuth 2.0 token.
+ * @param {string} fileId - The ID of the file to append to.
+ * @param {string} text - The text to append.
+ */
+function appendToFile(token, fileId, text) {
+    const url = `https://docs.googleapis.com/v1/documents/${fileId}:batchUpdate`;
+    const requests = [
+        {
+          insertText: {
+            text: text + '\n\n', // Add extra newline for spacing
+            endOfSegmentLocation: {}
+          }
+        }
+    ];
+
+    fetch(url, {
+        method: 'POST',
+        headers: {
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ requests })
+    })
+    .then(response => response.json())
+    .then(data => {
+        console.log('Successfully appended to the document:', data);
+    })
+    .catch(error => {
+        console.error('Error appending to document:', error);
+    });
+}

--- a/chrome/content.js
+++ b/chrome/content.js
@@ -1,0 +1,2 @@
+// content.js
+console.log("Content script loaded.");

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,0 +1,31 @@
+{
+  "manifest_version": 3,
+  "name": "Google Drive Vocabulary",
+  "version": "1.0",
+  "description": "Translate English words to Korean and save them to Google Drive.",
+  "permissions": [
+    "identity",
+    "contextMenus",
+    "storage"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "content.js"
+      ]
+    }
+  ],
+  "oauth2": {
+    "client_id": "YOUR_CLIENT_ID.apps.googleusercontent.com",
+    "scopes": [
+      "https://www.googleapis.com/auth/drive.file",
+      "https://www.googleapis.com/auth/documents"
+    ]
+  }
+}


### PR DESCRIPTION
This commit introduces a new Chrome extension that allows users to translate English words to Korean and save them, along with their phonetic symbols and definitions, to a Google Doc.

Key features:
- Right-click context menu to select and translate English words.
- Fetches phonetic symbols and definitions from dictionaryapi.dev.
- Translates English to Korean using the MyMemory API.
- Integrates with Google Drive to save vocabulary entries.
- Creates a new Google Doc for each day's vocabulary list.
- Includes a detailed README.md with setup instructions for OAuth 2.0.
- Sets up a GitHub Actions workflow for automated releases.